### PR TITLE
Adai-Application-ServiceCollectionExtensions-Initial

### DIFF
--- a/src/backend/WorkTimeTrackerService/WorkTimeTrackerService.Application/ServiceCollectionExtensions.cs
+++ b/src/backend/WorkTimeTrackerService/WorkTimeTrackerService.Application/ServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using MediatR;
+using FluentValidation;
+using WorkTimeTrackerService.Application.Behaviors;
+
+namespace WorkTimeTrackerService.Application
+{
+  public static class ServiceCollectionExtensions
+  {
+    public static IServiceCollection AddApplication(this IServiceCollection services,
+           Assembly[] automapperAssemblies)
+    {
+      //Нужно попробовать вместо передачи ряда Assembly, передать исполняющуюся сборку а именно WorkTimeTrackerService.Api Assembly
+      services.AddAutoMapper(automapperAssemblies);
+      services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+      services.AddMediatR(Assembly.GetExecutingAssembly());
+      services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+      services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+
+      return services;
+    }
+  }
+}

--- a/src/backend/WorkTimeTrackerService/WorkTimeTrackerService.Application/WorkTimeTrackerService.Application.csproj
+++ b/src/backend/WorkTimeTrackerService/WorkTimeTrackerService.Application/WorkTimeTrackerService.Application.csproj
@@ -5,9 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.4.0" />
     <PackageReference Include="MediatR" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added ServiceCollectionExtensions for:
1) services.AddAutoMapper(automapperAssemblies) - we associate data from the Application assembly with the Api.Models level so that our services that work through the Domain do not swear.
2) services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly()) - we get all validators from the assembly for our ValidationBehavior to work.
3) services.AddMediatR(Assembly.GetExecutingAssembly()) - we get all our commands and requests for working with data, it is mainly needed for the CQRS design pattern
4) services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>)) - we register our logging middleware in the general services of the application, Transient - the life cycle of our service is very short, a separate LoggingBehavior will be created for each request
5) services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>)) - we register our validation middleware in the general services of the application, Transient - the life cycle of our service is very short, for each request a separate ValidationBehavior will be created