### PR TITLE
Adai-Api.Model-EntityModels-ProjectTaskStatus

### DIFF
--- a/src/backend/WorkTimeTrackerService/WorkTimeTrackerService.Api.Model/EntityModels/Dictionaries/ProjectTaskStatus.cs
+++ b/src/backend/WorkTimeTrackerService/WorkTimeTrackerService.Api.Model/EntityModels/Dictionaries/ProjectTaskStatus.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace WorkTimeTrackerService.Api.Model.EntityModels.Dictionaries
+{
+  public class ProjectTaskStatus : BaseEntity<Guid>
+  {
+    [Required]
+    [StringLength(200)]
+    public string Status { get; set; }
+  }
+}


### PR DESCRIPTION
The Project Task Status entity has been added. This class differs from the Domain class in that it does not contain fields: List<ProjectTask> ProjectTasks.