### PR TITLE
Adai-Api.Model-EntityModels-ProjectTaskType

### DIFF
--- a/src/backend/WorkTimeTrackerService/WorkTimeTrackerService.Api.Model/EntityModels/Dictionaries/ProjectTaskType.cs
+++ b/src/backend/WorkTimeTrackerService/WorkTimeTrackerService.Api.Model/EntityModels/Dictionaries/ProjectTaskType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace WorkTimeTrackerService.Api.Model.EntityModels.Dictionaries
+{
+  public class ProjectTaskType : BaseEntity<Guid>
+  {
+    //Я сделал его классом так как enum не расширяем
+    //Как я принял такое решение: https://habr.com/ru/post/476650/ 
+    [Required]
+    [StringLength(200)]
+    public string Type { get; set; }
+  }
+}


### PR DESCRIPTION
The Project Task Type entity has been added. This class differs from the Domain class in that it does not contain fields: List<ProjectTask> ProjectTasks.